### PR TITLE
Add exclusion for phoenix's %Plug.Upload{}

### DIFF
--- a/lib/morpheus.ex
+++ b/lib/morpheus.ex
@@ -210,6 +210,8 @@ defmodule Morpheus do
       iex> Morpheus.convert_map_keys("not_a_map", &Morpheus.snake_to_camel/1)
       "not_a_map"
   """
+  def convert_map_keys(%{__struct__: Plug.Upload} = value, _conversion_function), do: value
+    
   def convert_map_keys(map, conversion_function) when is_map(map) do
     map
     |> Enum.map(fn {key, value} ->


### PR DESCRIPTION
Resolves https://github.com/itzmidinesh/morpheus/issues/1

This is kind of a very specific patch, it would be nice to have some general way to exclude certain structs that shouldn't be converted, but considering it breaks a core feature of phoenix I think it's probably OK